### PR TITLE
APP-470 Fix to encoding skip check to include other encoded oauth_urls

### DIFF
--- a/app/Jasonette/Jason.m
+++ b/app/Jasonette/Jason.m
@@ -3257,7 +3257,7 @@
      *******************************/
     
     JasonMemory *memory = [JasonMemory client];
-    BOOL isGoogleAuth = [memory._register[@"$jason"][@"authMethod"] isEqual:@"firebase/google"];
+    BOOL isGoogleOrOAuth = [memory._register[@"$jason"][@"authMethod"] isEqual:@"firebase/google"] || [memory._register[@"$jason"] objectForKey:@"oauth_redirect"];
     
     dispatch_async(dispatch_get_main_queue(), ^{
         
@@ -3289,7 +3289,7 @@
             
             // APP-470: Workaround `[JasonHelper linkify:href[@"url"]]` break the google login URL
             NSURL *URL = nil;
-            if (isGoogleAuth) {
+            if (isGoogleOrOAuth) {
                 URL = [NSURL URLWithString:href[@"url"]];
             } else {
                 NSString *encoded_url = [JasonHelper linkify:href[@"url"]];


### PR DESCRIPTION
Not sure when this originally was added since at some point with 470 changes bbon worked.
But bbon was now failing because it was getting double encoded.
Now any url that came from oauth_redirect or the firebase authMethod will skip encoding.